### PR TITLE
Implement support for unbalanced loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build/
 pkg/
 
 TestResults/
+/src/.vs
+/.vs

--- a/src/brainfuck.Core/brainfuck.cs
+++ b/src/brainfuck.Core/brainfuck.cs
@@ -7,14 +7,22 @@
         private readonly char[] _commands;
         private readonly int _length;
         private int _instructionPointer;
+        private int _bracket;
         public string Out { get; private set; }
 
         public brainfuck(string statement)
         {
             _virtualMemory = new char[30720];
             _pointer = 0;
-            _commands = statement.ToCharArray();
-            _length = _commands.Length;
+            _commands = new char[statement.Length];
+            for (int i = 0; i < statement.Length; i++)
+            {
+                if (statement[i] == '+' || statement[i] == '-' || statement[i] == '<' || statement[i] == '>' || statement[i] == '[' || statement[i] == ']' || statement[i] == '.' || statement[i] == ',')
+                {
+                    _commands[_length] = statement[i];
+                    _length++;
+                }
+            }
         }
 
         public void Run()
@@ -29,22 +37,41 @@
                     case '<': _pointer--; break;
                     case '+': _virtualMemory[_pointer]++; break;
                     case '-': _virtualMemory[_pointer]--; break;
-                    case '.': 
-                        Out += _virtualMemory[_pointer].ToString(); 
+                    case '.':
+                        Out += _virtualMemory[_pointer].ToString();
                         break;
                     case ',':
                         _virtualMemory[_pointer] = System.Console.ReadKey().KeyChar;
                         break;
-                    case '[': 
+                    case '[':
                         if (_virtualMemory[_pointer] == 0)
-                            while (_commands[_instructionPointer] != ']') 
-                                _instructionPointer++;
+                        {
+                            _instructionPointer++;
+                            while (_commands[_instructionPointer] != ']' || _bracket > 0)
+                            {
+                                if (_commands[_instructionPointer] == '[')
+                                    _bracket++;
+                                else if (_commands[_instructionPointer] == ']')
+                                    _bracket--;
+                                if (_instructionPointer < _commands.Length - 1)
+                                    _instructionPointer++;
+                            }
+                        }
                         break;
-
-                    case ']': 
+                    case ']':
                         if (_virtualMemory[_pointer] != 0)
-                            while (_commands[_instructionPointer] != '[') 
-                                _instructionPointer--;
+                        {
+                            _instructionPointer--;
+                            while (_commands[_instructionPointer] != '[' || _bracket > 0)
+                            {
+                                if (_commands[_instructionPointer] == ']')
+                                    _bracket++;
+                                else if (_commands[_instructionPointer] == '[')
+                                    _bracket--;
+                                if (_instructionPointer > 0)
+                                    _instructionPointer--;
+                            }
+                        }
                         break;
                 }
                 _instructionPointer++;


### PR DESCRIPTION
I know this is an old repo, but I was messing around and realised that unbalanced loops aren't supported. This means that many BF scripts will not run correctly, as loops are jumping to the wrong location.  

I've just added a bracket counter, which ensures that brackets will always jump to their actual pair, rather than the first bracket they come across.  

With this fix applied, it was able to successfully run every [BF test](https://github.com/rdebath/Brainfuck/blob/master/bitwidth.b) that I fed it.